### PR TITLE
Openemr external pr 8404 ci coverage api experiment 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+    ENABLE_COVERAGE: "false"
+
 jobs:
 
   build_apache_82_114:
@@ -55,53 +58,92 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
+
 
   build_apache_83_116:
     name: PHP 8.3 - Apache - MariaDB 11.6 (Rolling version)
@@ -110,6 +152,7 @@ jobs:
       DOCKER_DIR: apache_83_116
       OPENEMR_DIR: /var/www/localhost/htdocs/openemr
       CHROMIUM_INSTALL: "apk update; apk add --no-cache chromium chromium-chromedriver; export PANTHER_CHROME_DRIVER_BINARY=/usr/lib/chromium/chromedriver"
+      ENABLE_COVERAGE: "true"
     steps:
       - uses: actions/checkout@v4
 
@@ -147,53 +190,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_114:
     name: PHP 8.3 - Apache - MariaDB 11.4
@@ -239,53 +320,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_1011:
     name: PHP 8.3 - Apache - MariaDB 10.11
@@ -331,53 +450,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_106:
     name: PHP 8.3 - Apache - MariaDB 10.6
@@ -423,53 +580,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_105:
     name: PHP 8.3 - Apache - MariaDB 10.5
@@ -515,53 +710,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_84:
     name: PHP 8.3 - Apache - MySQL 8.4
@@ -608,53 +841,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_80:
     name: PHP 8.3 - Apache - MySQL 8.0
@@ -701,53 +972,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_57:
     name: PHP 8.3 - Apache - MySQL 5.7
@@ -794,53 +1103,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_82:
     name: PHP 8.2 - Nginx - MariaDB 11.4
@@ -886,53 +1233,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_83:
     name: PHP 8.3 - Nginx - MariaDB 11.4
@@ -978,54 +1363,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
 
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_84:
     name: PHP 8.4 - Nginx - MariaDB 11.4
@@ -1071,53 +1493,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_85:
     name: PHP 8.5 - Nginx - MariaDB 11.4
@@ -1163,50 +1623,56 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -142,7 +141,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -235,7 +233,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -328,7 +325,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -421,7 +417,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -514,7 +509,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -886,7 +880,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -979,7 +972,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -1073,7 +1065,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -1166,7 +1157,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -14,8 +14,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// below brings in autoloader
-require_once("./../_rest_config.php");
 
 use OpenEMR\Common\Auth\UuidUserAccount;
 use OpenEMR\Common\Csrf\CsrfUtils;
@@ -28,6 +26,13 @@ use OpenEMR\FHIR\SMART\SmartLaunchController;
 use OpenEMR\Events\RestApiExtend\RestApiCreateEvent;
 use OpenEMR\Telemetry\TelemetryService;
 use Psr\Http\Message\ResponseInterface;
+use OpenEMR\Tools\Coverage\CoverageHelper;
+
+
+// below brings in autoloader
+require_once("./../_rest_config.php");
+$logger = new SystemLogger();
+CoverageHelper::setupCodeCoverageIfEnabled();
 
 $gbl = RestConfig::GetInstance();
 $restRequest = new HttpRestRequest($gbl, $_SERVER);
@@ -35,7 +40,6 @@ $routes = array();
 
 // Parse needed information from Redirect or REQUEST_URI
 $resource = $gbl::getRequestEndPoint();
-$logger = new SystemLogger();
 $logger->debug("dispatch.php requested", ["resource" => $resource, "method" => $_SERVER['REQUEST_METHOD']]);
 
 $skipApiAuth = false;
@@ -422,3 +426,5 @@ try {
 } catch (\Exception $e) {
     $logger->error("dispatch.php telemetry error", ['exception' => $e]);
 }
+
+

--- a/ci/apache_82_114/docker-compose.yml
+++ b/ci/apache_82_114/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.18
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_1011/docker-compose.yml
+++ b/ci/apache_83_1011/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mysqld','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_105/docker-compose.yml
+++ b/ci/apache_83_105/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mysqld','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_106/docker-compose.yml
+++ b/ci/apache_83_106/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mysqld','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_114/docker-compose.yml
+++ b/ci/apache_83_114/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_116/docker-compose.yml
+++ b/ci/apache_83_116/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_57/docker-compose.yml
+++ b/ci/apache_83_57/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always

--- a/ci/apache_83_80/docker-compose.yml
+++ b/ci/apache_83_80/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always

--- a/ci/apache_83_84/docker-compose.yml
+++ b/ci/apache_83_84/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -10,14 +10,31 @@
 # Bash library for openemr ci
 #
 
+set -xeuo pipefail
+
+coverage_args=(
+    --coverage-filter apis
+    --coverage-filter gacl
+    --coverage-filter interface
+    --coverage-filter library
+    --coverage-filter modules
+    --coverage-filter oauth2
+    --coverage-filter portal
+    --coverage-filter sites
+    --coverage-filter src
+    --coverage-filter tests
+    --coverage-text
+    --path-coverage
+)
+
 composer_github_auth() {
-    githubToken=`echo MjE2OTcwOGE2MmM5ZWRiMzA3NGFmNGVjMmZkOGE0MWY2YzVkMDJhZgo= | base64 --decode`
-    githubTokenRateLimitRequest=`curl -H "Authorization: token $githubToken" https://api.github.com/rate_limit`
-    githubTokenRateLimit=`echo $githubTokenRateLimitRequest | jq '.rate.remaining'`
+    githubToken=$(base64 --decode <<< MjE2OTcwOGE2MmM5ZWRiMzA3NGFmNGVjMmZkOGE0MWY2YzVkMDJhZgo=)
+    githubTokenRateLimitRequest=$(curl -H "Authorization: token $githubToken" https://api.github.com/rate_limit)
+    githubTokenRateLimit=$(jq '.rate.remaining' <<< "$githubTokenRateLimitRequest")
     echo "Number of github api requests remaining is $githubTokenRateLimit"
-    if [ "$githubTokenRateLimit" -gt 500 ]; then
-        echo "Trying to use composer github api token"
-        if `composer config --global --auth github-oauth.github.com "$githubToken"`; then
+    if (( githubTokenRateLimit > 500 )); then
+        echo 'Trying to use composer github api token'
+        if composer config --global --auth github-oauth.github.com "$githubToken"; then
             echo "github composer token worked"
         else
             echo "github composer token did not work"
@@ -27,123 +44,114 @@ composer_github_auth() {
     fi
 }
 
+##
+# Technically dc is a calculator command in linux,
+# but it's rarely used in the same context as docker compose.
+dc() {
+    docker compose --project-directory "ci/${DOCKER_DIR}" "$@"
+}
+
+_exec() {
+    dc exec --env XDEBUG_MODE=coverage --workdir "${OPENEMR_DIR}" openemr "$@"
+}
+
 dockers_env_start() {
-    failTest=false
-    cd ci/${DOCKER_DIR} || failTest=true
-    docker compose up -d || failTest=true
-    cd ../../ || failTest=true
-    if $failTest; then
-      exit 1
+    dc up --detach
+}
+
+actions_chmod() {
+    # TODO, figure out how not to require the below line (maybe chown or something like that)
+    if [[ -z ${GITHUB_RUN_ID:-} ]]; then
+        echo 'skipping chmod because this is not running in github actions'
+        return
     fi
+    sudo chmod "$@"
 }
 
 main_build() {
-      failTest=false
-      # TODO, figure out how not to require the below line (maybe chown or something like that)
-      sudo chmod -R 0777 .
-      composer install || failTest=true
-      npm install || failTest=true
-      npm run build || failTest=true
-      composer global require phing/phing || failTest=true
-      $HOME/.composer/vendor/bin/phing vendor-clean || failTest=true
-      $HOME/.composer/vendor/bin/phing assets-clean || failTest=true
-      composer global remove phing/phing || failTest=true
-      composer dump-autoload -o || failTest=true
-      rm -fr node_modules || failTest=true
-      if $failTest; then
-        exit 1
-      fi
+    actions_chmod -R 0777 .
+    local composer_home
+    composer_home=$(composer --no-interaction config --global --absolute home) 2> /dev/null
+    composer install
+    npm ci
+    npm run build
+    composer global require phing/phing
+    "${composer_home}/vendor/bin/phing" vendor-clean
+    "${composer_home}/vendor/bin/phing" assets-clean
+    composer global remove phing/phing
+    composer dump-autoload -o
+    rm -fr node_modules
 }
 
-ccda_build() {
-    failTest=false
-    cd ccdaservice || failTest=true
-    npm install || failTest=true
-    cd ../ || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+ccda_build() (
+    cd ccdaservice
+    npm ci
+)
+
+configure_coverage() {
+    _exec sh -c '
+      XDEBUG_IDE_KEY=unimportant XDEBUG_ON=yes ../xdebug.sh
+      mkdir -p ./coverage
+      curl -sSLO https://phar.phpunit.de/phpcov-11.0.0.phar
+    '
+}
+
+phpcov() {
+    _exec php -d memory_limit=8G phpcov-11.0.0.phar "$@"
 }
 
 install_configure() {
-    failTest=false
-    sudo chmod 666 sites/default/sqlconf.php || failTest=true
-    sudo chmod -R 777 sites/default/documents || failTest=true
-    sed -e 's@^exit;@ @' < contrib/util/installScripts/InstallerAuto.php > contrib/util/installScripts/InstallerAutoTemp.php || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "php -f ${OPENEMR_DIR}/contrib/util/installScripts/InstallerAutoTemp.php rootpass=root server=mysql loginhost=%" || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "rm -f ${OPENEMR_DIR}/contrib/util/installScripts/InstallerAutoTemp.php" || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "INSERT INTO product_registration (opt_out) VALUES (1)" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_api\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_fhir_api\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_portal_api\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 3 WHERE gl_name = \"oauth_password_grant\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_system_scopes_api\"" openemr' || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-
-build_test_unit() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite unit --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+    actions_chmod 0666 sites/default/sqlconf.php
+    actions_chmod -R 0777 sites/default/documents
+    sed -e 's@^exit;@ @' < contrib/util/installScripts/InstallerAuto.php > contrib/util/installScripts/InstallerAutoTemp.php
+    _exec php -f ./contrib/util/installScripts/InstallerAutoTemp.php rootpass=root server=mysql loginhost=%
+    _exec rm -f ./contrib/util/installScripts/InstallerAutoTemp.php
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1)' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_portal_api"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 3 WHERE gl_name = "oauth_password_grant"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_system_scopes_api"' openemr
 }
 
 build_test_e2e() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; export PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage'; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+    _exec sh -c "${CHROMIUM_INSTALL};
+                 export PANTHER_NO_SANDBOX=1;
+                 export PANTHER_CHROME_ARGUMENTS=--disable-dev-shm-usage;
+                 php -d memory_limit=8G ./vendor/bin/phpunit --testsuite e2e \
+                                                             --testdox"
 }
 
-build_test_api() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite api --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+phpunit() {
+    _exec php -d memory_limit=8G ./vendor/bin/phpunit --testdox "$@"
 }
 
-build_test_fixtures() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite fixtures --testdox" || failTest=true
-    if $failTest; then
-      exit 1
+##
+# Run the tests, enabling coverage if set.
+# Coverage is not handled for api or e2e tests.
+build_test() {
+    local testsuite="$1"
+    local -a args=( --testsuite "$testsuite" )
+    shift
+    case "$testsuite" in
+        api) phpunit "${args[@]}" "$@"
+             return
+             ;;
+        e2e) build_test_e2e "$@"
+             return
+             ;;
+    esac
+    if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        args+=(
+            --coverage-php "./coverage/coverage.${testsuite}.cov"
+            "${coverage_args[@]}"
+        )
     fi
+    phpunit "${args[@]}" "$@"
 }
 
-build_test_services() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite services --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+merge_coverage() {
+    phpcov merge coverage --clover coverage.clover.xml \
+                          --html htmlcov coverage \
+                          --text /dev/stdout
 }
-
-build_test_validators() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite validators --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-
-build_test_controllers() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite controllers --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-
-build_test_common() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite common --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-

--- a/ci/nginx_82/docker-compose.yml
+++ b/ci/nginx_82/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.2
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/ci/nginx_83/docker-compose.yml
+++ b/ci/nginx_83/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.3
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/ci/nginx_84/docker-compose.yml
+++ b/ci/nginx_84/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.4
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/ci/nginx_85/docker-compose.yml
+++ b/ci/nginx_85/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.5
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
         }
     },
     "require-dev": {
+        "phpunit/php-code-coverage": "^11.0",
         "phpunit/phpunit": "11.*",
         "symfony/panther": "2.*",
         "zircote/swagger-php": "3.*"

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,8 @@
         "phpunit/php-code-coverage": "^11.0",
         "phpunit/phpunit": "11.*",
         "symfony/panther": "2.*",
-        "zircote/swagger-php": "3.*"
+        "zircote/swagger-php": "3.*",
+        "phpunit/phpcov": "^10.0"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0c87ea2b05978e14645961e3106ad73",
+    "content-hash": "9e66638d862caeb2793e11b7b968d767",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -13442,16 +13442,16 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2",
         "ext-intl": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e66638d862caeb2793e11b7b968d767",
+    "content-hash": "375fcf86ccfae87380e2a2bab587f7ef",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -11740,6 +11740,68 @@
                 }
             ],
             "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpcov",
+            "version": "10.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpcov.git",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "reference": "a6029f35b6aa4934f3acfe520e60aa7a0285e845",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.8",
+                "phpunit/php-file-iterator": "^5.1",
+                "phpunit/phpunit": "^11.5.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/version": "^5.0.2"
+            },
+            "bin": [
+                "phpcov"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "CLI frontend for php-code-coverage",
+            "homepage": "https://github.com/sebastianbergmann/phpcov",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpcov/issues",
+                "source": "https://github.com/sebastianbergmann/phpcov/tree/10.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T09:43:28+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -55,9 +55,11 @@ services:
       EASY_DEV_MODE_NEW: "yes"
       DEVELOPER_TOOLS: "yes"
       XDEBUG_ON: 1
+      XDEBUG_MODE: coverage,debug,profile
       XDEBUG_PROFILER_ON: 1
       # setting xdebug client host for cases where xdebug.discover_client_host fails
       XDEBUG_CLIENT_HOST: host.docker.internal
+      ENABLE_REMOTE_COVERAGE: 1
       GITHUB_COMPOSER_TOKEN: c313de1ed5a00eb6ff9309559ec9ad01fcc553f0
       GITHUB_COMPOSER_TOKEN_ENCODED: ZWU5YWIwZWNiM2ZlN2I4YThlNGQ0ZWZiNjMyNDQ5MjFkZTJhMTY2OQo=
       OPENEMR_DOCKER_ENV_TAG: easy-dev-docker

--- a/interface/patient_file/encounter/trend_form.php
+++ b/interface/patient_file/encounter/trend_form.php
@@ -135,7 +135,7 @@ $(function () {
   // For LBF the <td> has an id of label_id_$fieldid
   $(".graph").on("click", function(e){ show_graph(<?php echo js_escape($formname); ?>, this.id.substring(9), $(this).text()) });
 <?php } else { ?>
-  $(".graph").on("click", function(e){ show_graph('form_vitals', this.id, '$(this).text()') });
+  $(".graph").on("click", function(e){ show_graph('form_vitals', this.id, $(this).text()) });
 <?php } ?>
 
   // Show hovering effects for the .graph links

--- a/oauth2/authorize.php
+++ b/oauth2/authorize.php
@@ -17,7 +17,9 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\RestControllers\AuthorizationController;
+use OpenEMR\Tools\Coverage\CoverageHelper;
 
+CoverageHelper::setupCodeCoverageIfEnabled();
 $gbl = RestConfig::GetInstance();
 if (empty($gbl::$SITE)) {
     http_response_code(401);

--- a/src/Tools/Coverage/CoverageHelper.php
+++ b/src/Tools/Coverage/CoverageHelper.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace OpenEMR\Tools\Coverage;
+
+use ReflectionMethod;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Driver\Selector;
+use SebastianBergmann\CodeCoverage\Filter;
+use SebastianBergmann\CodeCoverage\Report\PHP;
+use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
+use PHPUnit\Framework\Attributes\Test;
+use function microtime;
+use function register_shutdown_function;
+
+class CoverageHelper
+{
+    public static function resolveCoverageId(string $baseClass, string|int $dataName): string
+    {
+        return $baseClass . self::resolveTestMethod($baseClass) . self::resolveTestDataSet($dataName);
+    }
+
+    private static function resolveTestMethod(string $baseClass): string
+    {
+        $stack = debug_backtrace();
+
+        // Get the first class in the stack which is baseClass, then get its first test method
+        foreach ($stack as $t) {
+            if (!isset($t['object'], $t['class']) || $t['class'] !== $baseClass) {
+                continue;
+            }
+
+            // The test method is the first one in the backtrace which has the Test attribute
+            $ref = new ReflectionMethod($t['object'], $t['function']);
+            $attributes = $ref->getAttributes();
+            foreach ($attributes as $attr) {
+                if ($attr->getName() === Test::class) {
+                    return '::' . $t['function'];
+                }
+            }
+        }
+
+        return '';
+    }
+
+    public static function createTargetedCodeCoverage(string $shutdownExportBasePath) {
+        $filter = new Filter();
+        $filter->includeFiles([
+            __DIR__ . '/../../../apis/dispatch.php',
+            __DIR__ . '/../../../_rest_config.php',
+            __DIR__ . '/../../../_rest_routes.inc.php',
+            __DIR__ . '/../../../oauth2/authorize.php',
+            __DIR__ . '/../../../oauth2/provider/.well-known/discovery.php',
+            __DIR__ . '/../../../oauth2/provider/jwk.php'
+        ]);
+        $filter->includeDirectory(
+            __DIR__ . '/../../../src/'
+        );
+        $coverage = new CodeCoverage((new Selector())->forLineCoverage($filter), $filter);
+        // When the process is shut down, dump a partial coverage report in PHP format
+        register_shutdown_function(function () use ($shutdownExportBasePath, $coverage): void {
+            $coverage->stop();
+            // now clean it all up.
+            $id = (string)microtime(as_float: true);
+            $covPath = $shutdownExportBasePath . '/' . $id . '.cov';
+            (new PHP())->process($coverage, $covPath);
+        });
+        return $coverage;
+    }
+
+    /**
+     * @param string[] $dirs - List of directories to collect coverage from
+     * @param $shutdownExportBasePath - Directory where the coverage report will be dumped
+     */
+    public static function createCoverageForDirectories(
+        array  $dirs,
+        string $shutdownExportBasePath,
+    ): CodeCoverage
+    {
+        // Determine from what directories we want coverage to be collected
+        $filter = new Filter();
+        foreach ($dirs as $dir) {
+            foreach ((new FileIteratorFacade())->getFilesAsArray($dir) as $file) {
+                $filter->includeFile($file);
+            }
+        }
+
+        $coverage = new CodeCoverage((new Selector())->forLineCoverage($filter), $filter);
+
+        // When the process is shut down, dump a partial coverage report in PHP format
+        register_shutdown_function(function () use ($shutdownExportBasePath, $coverage): void {
+            $id = (string)microtime(as_float: true);
+            $covPath = $shutdownExportBasePath . '/' . $id . '.cov';
+            (new PHP())->process($coverage, $covPath);
+        });
+
+        return $coverage;
+    }
+
+    private static function resolveTestDataSet(string|int $dataName): string
+    {
+        return !empty($dataName) ? '#' . $dataName : '';
+    }
+
+    public static function setupCodeCoverageIfEnabled()
+    {
+        if (getenv("ENABLE_REMOTE_COVERAGE")) {
+// grab the http header for X-Coverage-Id
+            $coverageRootPath = defined('COVERAGE_ROOT_PATH') ? COVERAGE_ROOT_PATH : __DIR__ . '/../../../coverage';
+            $coverageId = null;
+            $coverageId = $_SERVER['HTTP_X_COVERAGE_ID'] ?? '';
+
+            if ($coverageId != null) {
+                error_log("Coverage id is " . $coverageId);
+                // TODO: expand to other code systems... excludeDirectory was deprecated so we have to provide a list of all the places we want to include
+                $coverage = CoverageHelper::createTargetedCodeCoverage($coverageRootPath);
+                $coverage->start($coverageId);
+            }
+        }
+    }
+}

--- a/tests/Tests/Api/ApiTestCase.php
+++ b/tests/Tests/Api/ApiTestCase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OpenEMR\Tests\Api;
+
+use OpenEMR\Tools\Coverage\CoverageHelper;
+use PHPUnit\Framework\TestCase;
+
+class ApiTestCase extends TestCase
+{
+    private string $baseUrl;
+
+    /**
+     * @var ApiTestClient
+     * TODO: we may want to switch this to private after refactoring tests to use the new ApiTestClient
+     */
+    protected $testClient;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
+        $this->testClient = new ApiTestClient($baseUrl, false);
+        $this->baseUrl = $baseUrl;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->testClient->cleanupRevokeAuth();
+        $this->testClient->cleanupClient();
+    }
+    public function setAuthToken() {
+        return $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, array(), 'private', $this->getCoverageId());
+    }
+
+    public function get(string $url, array $params = []) {
+        return $this->testClient->get($url, $params, $this->getCoverageId());
+    }
+
+    public function post(string $url, array $data, bool $isJson = true) {
+        $coverageId = $this->getCoverageId();
+        return $this->testClient->post($url, $data, $isJson, $coverageId);
+    }
+
+    public function put(string $url, string $id, array $data) {
+        $coverageId = $this->getCoverageId();
+        return $this->testClient->put($url, $id, $data, $coverageId);
+    }
+
+    public function getOne(string $url, string $id) {
+        return $this->testClient->getOne($url, $id, $this->getCoverageId());
+    }
+
+    protected function getCoverageId() {
+        return CoverageHelper::resolveCoverageId(static::class, $this->dataName());
+    }
+
+}

--- a/tests/Tests/Api/ApiTestClientTest.php
+++ b/tests/Tests/Api/ApiTestClientTest.php
@@ -2,21 +2,27 @@
 
 namespace OpenEMR\Tests\Api;
 
-use OpenEMR\Tests\Api\ApiTestClient;
-use PHPUnit\Framework\TestCase;
+use OpenEMR\RestControllers\AuthorizationController;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 
 /**
  * Test cases for the OpenEMR Api Test Client
  * NOTE: currently disabled (by naming convention) until work is completed to support running as part of Travis CI
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
+ * TODO: this tests the api requests for authorization controller as well, not really a true unit test.
  */
-class ApiTestClientTest extends TestCase
+#[CoversClass(ApiTestClient::class)]
+#[CoversClass(AuthorizationController::class)]
+#[CoversMethod(ApiTestClient::class, '::getConfig')]
+#[CoversMethod(ApiTestClient::class, '::setAuthToken')]
+#[CoversMethod(ApiTestClient::class, '::removeAuthToken')]
+class ApiTestClientTest extends ApiTestCase
 {
     const EXAMPLE_API_ENDPOINT = "/apis/default/api/facility";
     const EXAMPLE_API_ENDPOINT_INVALID_SITE = "/apis/baddefault/api/facility";
@@ -24,170 +30,161 @@ class ApiTestClientTest extends TestCase
     const API_ROUTE_SCOPE = "api:oemr";
 
     /**
-     * @var ApiTestClient
-     */
-    private $client;
-
-    /**
      * Configures the test client using environment variables and reasonable defaults
      */
     protected function setUp(): void
     {
-        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
-        $this->client = new ApiTestClient($baseUrl, false);
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
     }
 
     /**
-     * @cover ::getConfig with a null value
+     * with a null value
      */
+    #[Test]
     public function testGetConfigWithNull()
     {
-        $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $this->setAuthToken();
         $this->expectException(\InvalidArgumentException::class);
-        $this->client->getConfig(null);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
+        $this->testClient->getConfig(null);
     }
 
     /**
-     * @cover ::getConfig for HTTP client settings
+     * for HTTP client settings
      */
+    #[Test]
     public function testGetConfig()
     {
-        $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
-        $this->assertFalse($this->client->getConfig("http_errors"));
-        $this->assertEquals(10, $this->client->getConfig("timeout"));
-        $this->assertNotNull($this->client->getConfig("base_uri"));
+        $this->setAuthToken();
+        $this->assertFalse($this->testClient->getConfig("http_errors"));
+        $this->assertEquals(10, $this->testClient->getConfig("timeout"));
+        $this->assertNotNull($this->testClient->getConfig("base_uri"));
 
-        $actualHeaders = $this->client->getConfig("headers");
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertEquals("application/json", $actualHeaders["Accept"]);
         $this->assertArrayHasKey("User-Agent", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests the automated testing when invalid credentials arguments are provided
-     * @covers ::setAuthToken with invalid credential argument
+     * with invalid credential argument
      */
+    #[Test]
     public function testApiAuthInvalidArgs()
     {
         try {
-            $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, array("foo" => "bar"));
+            $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, array("foo" => "bar"), 'private', $this->getCoverageId());
             $this->assertFalse(true, "expected InvalidArgumentException");
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true);
         }
 
-        $this->client->cleanupClient();
+        $this->testClient->cleanupClient();
 
         try {
-            $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, array("username" => "bar"));
+            $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, array("username" => "bar"), 'private', $this->getCoverageId());
             $this->assertFalse(true, "expected InvalidArgumentException");
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true);
         }
-
-        $this->client->cleanupClient();
     }
     /**
      * Tests OpenEMR OAuth when invalid client id is provided
-     * @covers ::setAuthToken with invalid credentials
+     * with invalid credentials
      */
+    #[Test]
     public function testApiAuthInvalidClientId()
     {
-        $actualValue = $this->client->setAuthToken(
+        $actualValue = $this->testClient->setAuthToken(
             ApiTestClient::OPENEMR_AUTH_ENDPOINT,
             ["client_id" => ApiTestClient::BOGUS_CLIENTID]
+            ,'private'
+            ,$this->getCoverageId()
         );
         $this->assertEquals(401, $actualValue->getStatusCode());
         $this->assertEquals('invalid_client', json_decode($actualValue->getBody())->error);
-
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR OAuth when invalid user credentials are provided
-     * @covers ::setAuthToken with invalid credentials
+     * with invalid credentials
      */
+    #[Test]
     public function testApiAuthInvalidUserCredentials()
     {
-        $actualValue = $this->client->setAuthToken(
+        $actualValue = $this->testClient->setAuthToken(
             ApiTestClient::OPENEMR_AUTH_ENDPOINT,
             array("username" => "bar", "password" => "boo")
+            ,'private'
+            ,$this->getCoverageId()
         );
         $this->assertEquals(400, $actualValue->getStatusCode());
         $this->assertEquals('Failed Authentication', json_decode($actualValue->getBody())->hint);
-
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Auth for the REST and FHIR APIs
-     * @cover ::setAuthToken
-     * @cover ::removeAuthToken
      */
+    #[Test]
     public function testApiAuth()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualHeaders = $this->client->getConfig("headers");
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayHasKey("Authorization", $actualHeaders);
 
         $authHeaderValue = substr($actualHeaders["Authorization"], 7);
         $this->assertGreaterThan(10, strlen($authHeaderValue));
 
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Auth for the REST and FHIR APIs (test refresh request after the auth)
-     * @cover ::setAuthToken
-     * @cover ::removeAuthToken
      */
+    #[Test]
     public function testApiAuthThenRefresh()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualHeaders = $this->client->getConfig("headers");
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayHasKey("Authorization", $actualHeaders);
 
         $authHeaderValue = substr($actualHeaders["Authorization"], 7);
         $this->assertGreaterThan(10, strlen($authHeaderValue));
 
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
         $refreshBody = [
             "grant_type" => "refresh_token",
-            "client_id" => $this->client->getClientId(),
-            "refresh_token" => $this->client->getRefreshToken()
+            "client_id" => $this->testClient->getClientId(),
+            "refresh_token" => $this->testClient->getRefreshToken()
         ];
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
             "Accept" => "application/json",
             "Content-Type" => "application/x-www-form-urlencoded"
             ]
         );
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
+        $authResponse = $this->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
         // set headers back to default
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
             "Accept" => "application/json",
             "Content-Type" => "application/json"
@@ -198,112 +195,104 @@ class ApiTestClientTest extends TestCase
         $this->assertGreaterThan(10, strlen($responseBody->id_token));
         $this->assertGreaterThan(10, strlen($responseBody->access_token));
         $this->assertGreaterThan(10, strlen($responseBody->refresh_token));
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Auth for the REST and FHIR APIs (test refresh request after the auth with bad refresh token)
-     * @cover ::setAuthToken
-     * @cover ::removeAuthToken
      */
+    #[Test]
     public function testApiAuthThenBadRefresh()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualHeaders = $this->client->getConfig("headers");
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayHasKey("Authorization", $actualHeaders);
 
         $authHeaderValue = substr($actualHeaders["Authorization"], 7);
         $this->assertGreaterThan(10, strlen($authHeaderValue));
 
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
         $refreshBody = [
             "grant_type" => "refresh_token",
-            "client_id" => $this->client->getClientId(),
+            "client_id" => $this->testClient->getClientId(),
             "refresh_token" => ApiTestClient::BOGUS_REFRESH_TOKEN
         ];
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/x-www-form-urlencoded"
             ]
         );
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
+        $authResponse = $this->testClient->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
         // set headers back to default
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/json"
             ]
         );
         $this->assertEquals(401, $authResponse->getStatusCode());
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth for the REST and FHIR APIs
      */
+    #[Test]
     public function testApiAuthExampleUse()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth for the REST and FHIR APIs (also does a
      *  token refresh and use with new token)
      */
+    #[Test]
     public function testApiAuthExampleUseThenRefreshThenUse()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
         $refreshBody = [
             "grant_type" => "refresh_token",
-            "client_id" => $this->client->getClientId(),
-            "refresh_token" => $this->client->getRefreshToken()
+            "client_id" => $this->testClient->getClientId(),
+            "refresh_token" => $this->testClient->getRefreshToken()
         ];
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/x-www-form-urlencoded"
             ]
         );
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
+        $authResponse = $this->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
         // set headers back to default
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/json"
@@ -314,34 +303,32 @@ class ApiTestClientTest extends TestCase
         $this->assertGreaterThan(10, strlen($responseBody->id_token));
         $this->assertGreaterThan(10, strlen($responseBody->access_token));
         $this->assertGreaterThan(10, strlen($responseBody->refresh_token));
-        $this->client->setBearer($responseBody->access_token);
+        $this->testClient->setBearer($responseBody->access_token);
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth for the REST and FHIR APIs (also does a
      *  token refresh and use with new token) with missing route scope
      */
+    #[Test]
     public function testApiAuthExampleUseThenRefreshThenUseWithMissingRouteScope()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
         // remove the route scope
@@ -349,19 +336,19 @@ class ApiTestClientTest extends TestCase
 
         $refreshBody = [
             "grant_type" => "refresh_token",
-            "client_id" => $this->client->getClientId(),
+            "client_id" => $this->testClient->getClientId(),
             "scope" => $scopeCustom,
-            "refresh_token" => $this->client->getRefreshToken()
+            "refresh_token" => $this->testClient->getRefreshToken()
         ];
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/x-www-form-urlencoded"
             ]
         );
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
+        $authResponse = $this->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
         // set headers back to default
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/json"
@@ -372,34 +359,32 @@ class ApiTestClientTest extends TestCase
         $this->assertGreaterThan(10, strlen($responseBody->id_token));
         $this->assertGreaterThan(10, strlen($responseBody->access_token));
         $this->assertGreaterThan(10, strlen($responseBody->refresh_token));
-        $this->client->setBearer($responseBody->access_token);
+        $this->testClient->setBearer($responseBody->access_token);
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(401, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth for the REST and FHIR APIs (also does a
      *  token refresh and use with new token) with missing endpoint scope
      */
+    #[Test]
     public function testApiAuthExampleUseThenRefreshThenUseWithMissingEndpointScope()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
         // remove the endpoint scope
@@ -407,19 +392,19 @@ class ApiTestClientTest extends TestCase
 
         $refreshBody = [
             "grant_type" => "refresh_token",
-            "client_id" => $this->client->getClientId(),
+            "client_id" => $this->testClient->getClientId(),
             "scope" => $scopeCustom,
-            "refresh_token" => $this->client->getRefreshToken()
+            "refresh_token" => $this->testClient->getRefreshToken()
         ];
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/x-www-form-urlencoded"
             ]
         );
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
+        $authResponse = $this->post(ApiTestClient::OAUTH_TOKEN_ENDPOINT, $refreshBody, false);
         // set headers back to default
-        $this->client->setHeaders(
+        $this->testClient->setHeaders(
             [
                 "Accept" => "application/json",
                 "Content-Type" => "application/json"
@@ -430,139 +415,131 @@ class ApiTestClientTest extends TestCase
         $this->assertGreaterThan(10, strlen($responseBody->id_token));
         $this->assertGreaterThan(10, strlen($responseBody->access_token));
         $this->assertGreaterThan(10, strlen($responseBody->refresh_token));
-        $this->client->setBearer($responseBody->access_token);
+        $this->testClient->setBearer($responseBody->access_token);
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(401, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth for the REST and FHIR APIs
      *  Then test revoking user
      */
+    #[Test]
     public function testApiAuthExampleUseThenRevoke()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $id_token = json_decode($actualValue->getBody())->id_token;
         $this->assertGreaterThan(10, strlen($id_token));
 
-        $actualResponse = $this->client->cleanupRevokeAuth();
+        $actualResponse = $this->testClient->cleanupRevokeAuth();
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $this->assertEquals("You have been signed out. Thank you.", $actualResponse->getBody());
 
-        $actualResponse = $this->client->cleanupRevokeAuth();
+        $actualResponse = $this->testClient->cleanupRevokeAuth();
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $this->assertEquals("You are currently not signed in.", $actualResponse->getBody());
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(400, $actualResponse->getStatusCode());
 
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint with Invalid Site After Getting Auth for the REST and FHIR APIs
      */
+    #[Test]
     public function testApiAuthExampleUseBadSite()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT_INVALID_SITE);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT_INVALID_SITE);
         $this->assertEquals(400, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth With Bad Bearer Token for the REST and FHIR APIs
      */
+    #[Test]
     public function testApiAuthExampleUseBadToken()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
-        $this->client->setBearer(ApiTestClient::BOGUS_ACCESS_TOKEN);
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $this->testClient->setBearer(ApiTestClient::BOGUS_ACCESS_TOKEN);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(401, $actualResponse->getStatusCode());
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
      * Tests OpenEMR API Example Endpoint After Getting Auth With Empty Bearer Token for the REST and FHIR APIs
      */
+    #[Test]
     public function testApiAuthExampleUseEmptyToken()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
+        $actualValue = $this->setAuthToken();
         $this->assertEquals(200, $actualValue->getStatusCode());
-        $this->assertGreaterThan(10, strlen($this->client->getIdToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getAccessToken()));
-        $this->assertGreaterThan(10, strlen($this->client->getRefreshToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getIdToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getAccessToken()));
+        $this->assertGreaterThan(10, strlen($this->testClient->getRefreshToken()));
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
 
-        $actualResponse = $this->client->get(self::EXAMPLE_API_ENDPOINT);
+        $actualResponse = $this->get(self::EXAMPLE_API_ENDPOINT);
         $this->assertEquals(401, $actualResponse->getStatusCode());
-
-        $this->client->cleanupRevokeAuth();
-        $this->client->cleanupClient();
     }
 
     /**
-     * @cover ::removeAuthToken when an auth token is not present
+     * when an auth token is not present
      */
+    #[Test]
     public function testRemoveAuthTokenNoToken()
     {
-        $this->client->removeAuthToken();
-        $actualHeaders = $this->client->getConfig("headers");
+        $this->testClient->removeAuthToken();
+        $actualHeaders = $this->testClient->getConfig("headers");
         $this->assertArrayNotHasKey("Authorization", $actualHeaders);
     }
 
+    #[Test]
     public function testApiAuthPublicClientDoesNotReturnRefreshToken()
     {
-        $actualValue = $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, [], 'public');
+        $actualValue = $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT, [], 'public', $this->getCoverageId());
         $this->assertEquals(200, $actualValue->getStatusCode(), "public client authorization should return valid status code");
-        $this->assertNull($this->client->getRefreshToken(), "Refresh token should be empty for public client");
-        $this->assertNotNull($this->client->getAccessToken(), "Access token should be populated");
-        $this->assertNotNull($this->client->getIdToken(), "Id token should be populated");
+        $this->assertNull($this->testClient->getRefreshToken(), "Refresh token should be empty for public client");
+        $this->assertNotNull($this->testClient->getAccessToken(), "Access token should be populated");
+        $this->assertNotNull($this->testClient->getIdToken(), "Id token should be populated");
     }
 }

--- a/tests/Tests/Api/CapabilityFhirTest.php
+++ b/tests/Tests/Api/CapabilityFhirTest.php
@@ -5,12 +5,12 @@ namespace OpenEMR\Tests\Api;
 use OpenEMR\FHIR\SMART\Capability;
 use OpenEMR\RestControllers\AuthorizationController;
 use OpenEMR\RestControllers\FHIR\FhirMetaDataRestController;
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Api\ApiTestClient;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 
 /**
  * Capability FHIR Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
@@ -18,21 +18,14 @@ use OpenEMR\Tests\Api\ApiTestClient;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class CapabilityFhirTest extends TestCase
+#[CoversClass(FhirMetaDataRestController::class)]
+#[CoversMethod(FhirMetaDataRestController::class, '::getMetaData')]
+class CapabilityFhirTest extends ApiTestCase
 {
     const CAPABILITY_FHIR_ENDPOINT = "/apis/default/fhir/metadata";
     const CAPABILITY_OAUTH_PREFIX = "/oauth2/default";
     const CAPABILITY_FHIR_ENDPOINT_INVALID_SITE = "/apis/baddefault/fhir/metadata";
 
-    /**
-     * @var ApiTestClient
-     */
-    private $testClient;
-
-    /**
-     * @var string
-     */
-    private $baseUrl;
 
     /**
      * Base url endpoint for oauth2 capability uris
@@ -42,42 +35,43 @@ class CapabilityFhirTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
-        $this->testClient = new ApiTestClient($baseUrl, false);
-        $this->baseUrl = $baseUrl;
         $this->oauthBaseUrl = $baseUrl . self::CAPABILITY_OAUTH_PREFIX;
     }
 
     public function tearDown(): void
     {
-        $this->testClient->cleanupRevokeAuth();
-        $this->testClient->cleanupClient();
+        parent::tearDown();
     }
 
     /**
-     * @covers ::get with an invalid path
+     * with an invalid path
      */
+    #[Test]
     public function testInvalidPathGet()
     {
-        $actualResponse = $this->testClient->get(self::CAPABILITY_FHIR_ENDPOINT . "ss");
+        $actualResponse = $this->get(self::CAPABILITY_FHIR_ENDPOINT . "ss");
         $this->assertEquals(401, $actualResponse->getStatusCode());
     }
 
     /**
-     * @covers ::get with an invalid site
+     * with an invalid site
      */
+    #[Test]
     public function testInvalidSiteGet()
     {
-        $actualResponse = $this->testClient->get(self::CAPABILITY_FHIR_ENDPOINT_INVALID_SITE);
+        $actualResponse = $this->get(self::CAPABILITY_FHIR_ENDPOINT_INVALID_SITE);
         $this->assertEquals(400, $actualResponse->getStatusCode());
     }
 
     /**
-     * @covers ::get
+     *
      */
+    #[Test]
     public function testGet()
     {
-        $actualResponse = $this->testClient->get(self::CAPABILITY_FHIR_ENDPOINT);
+        $actualResponse = $this->get(self::CAPABILITY_FHIR_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $body = $actualResponse->getBody();
         $this->assertNotNull($body); // make sure we have a body here

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -8,7 +8,7 @@ use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 
 /**
  * Facility API Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ * @coversDefaultClass \OpenEMR\RestControllers\FacilityRestController
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -2,8 +2,10 @@
 
 namespace OpenEMR\Tests\Api;
 
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Api\ApiTestClient;
+use OpenEMR\RestControllers\FacilityRestController;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 
 /**
@@ -16,22 +18,26 @@ use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class FacilityApiTest extends TestCase
+#[CoversClass(FacilityRestController::class)]
+#[CoversMethod(FacilityRestController::class, '::post')]
+#[CoversMethod(FacilityRestController::class, '::put')]
+#[CoversMethod(FacilityRestController::class, '::getOne')]
+#[CoversMethod(FacilityRestController::class, '::getAll')]
+class FacilityApiTest extends ApiTestCase
 {
     const FACILITY_API_ENDPOINT = "/apis/default/api/facility";
-    private $testClient;
 
     /**
      * @var FacilityFixtureManager
      */
     private $fixtureManager;
 
+    private $facilityRecord;
+
     protected function setUp(): void
     {
-        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
-        $this->testClient = new ApiTestClient($baseUrl, false);
-        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
-
+        parent::setUp();
+        $this->setAuthToken();
         $this->fixtureManager = new FacilityFixtureManager();
         $this->facilityRecord = (array) $this->fixtureManager->getSingleFacilityFixture();
     }
@@ -39,17 +45,17 @@ class FacilityApiTest extends TestCase
     protected function tearDown(): void
     {
         $this->fixtureManager->removeFixtures();
-        $this->testClient->cleanupRevokeAuth();
-        $this->testClient->cleanupClient();
+        parent::tearDown();
     }
 
     /**
-     * @covers ::post with an invalid facility request
+     * with an invalid facility request
      */
+    #[Test]
     public function testInvalidPost()
     {
         unset($this->facilityRecord["name"]);
-        $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
+        $actualResponse = $this->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
 
         $this->assertEquals(400, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -59,11 +65,12 @@ class FacilityApiTest extends TestCase
     }
 
     /**
-     * @covers ::post with a valid facility request
+     * with a valid facility request
      */
+    #[Test]
     public function testPost()
     {
-        $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
+        $actualResponse = $this->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
 
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -79,15 +86,16 @@ class FacilityApiTest extends TestCase
     }
 
     /**
-     * @covers ::put with an invalid uuid
+     * with an invalid uuid
      */
+    #[Test]
     public function testInvalidPut()
     {
-        $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
+        $actualResponse = $this->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $this->facilityRecord["email"] = "help@pennfirm.com";
-        $actualResponse = $this->testClient->put(
+        $actualResponse = $this->put(
             self::FACILITY_API_ENDPOINT,
             "not-a-uuid",
             $this->facilityRecord
@@ -101,18 +109,19 @@ class FacilityApiTest extends TestCase
     }
 
     /**
-     * @covers ::put with a valid resource uuid and payload
+     * with a valid resource uuid and payload
      */
+    #[Test]
     public function testPut()
     {
-        $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
+        $actualResponse = $this->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
 
         $facilityUuid = $responseBody["data"]["uuid"];
 
         $this->facilityRecord["email"] = "help@pennfirm.com";
-        $actualResponse = $this->testClient->put(self::FACILITY_API_ENDPOINT, $facilityUuid, $this->facilityRecord);
+        $actualResponse = $this->put(self::FACILITY_API_ENDPOINT, $facilityUuid, $this->facilityRecord);
 
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -124,11 +133,12 @@ class FacilityApiTest extends TestCase
     }
 
     /**
-     * @covers ::getOne with an invalid uuid
+     * with an invalid uuid
      */
+    #[Test]
     public function testGetOneInvalidId()
     {
-        $actualResponse = $this->testClient->getOne(self::FACILITY_API_ENDPOINT, "not-a-uuid");
+        $actualResponse = $this->getOne(self::FACILITY_API_ENDPOINT, "not-a-uuid");
         $this->assertEquals(400, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -138,18 +148,19 @@ class FacilityApiTest extends TestCase
     }
 
     /**
-     * @covers ::getOne with a valid uuid
+     * with a valid uuid
      */
+    #[Test]
     public function testGetOne()
     {
-        $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
+        $actualResponse = $this->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
         $facilityUuid = $responseBody["data"]["uuid"];
         $facilityId = $responseBody["data"]["id"];
 
-        $actualResponse = $this->testClient->getOne(self::FACILITY_API_ENDPOINT, $facilityUuid);
+        $actualResponse = $this->getOne(self::FACILITY_API_ENDPOINT, $facilityUuid);
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -161,13 +172,14 @@ class FacilityApiTest extends TestCase
 
 
     /**
-     * @covers ::getAll
+     *
      */
+    #[Test]
     public function testGetAll()
     {
         $this->fixtureManager->installFacilityFixtures();
 
-        $actualResponse = $this->testClient->get(self::FACILITY_API_ENDPOINT, array("facility_npi" => "0123456789"));
+        $actualResponse = $this->get(self::FACILITY_API_ENDPOINT, array("facility_npi" => "0123456789"));
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);

--- a/tests/Tests/Api/IntrospectionTest.php
+++ b/tests/Tests/Api/IntrospectionTest.php
@@ -3,11 +3,8 @@
 namespace OpenEMR\Tests\Api;
 
 use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Api\ApiTestClient;
-
 /**
  * Capability FHIR Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
@@ -15,12 +12,15 @@ use OpenEMR\Tests\Api\ApiTestClient;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
+#[CoversClass(ApiTestClient::class)]
 class IntrospectionTest extends TestCase
 {
     /**
      * @var ApiTestClient
      */
     private $client;
+
+    const OAUTH_INTROSPECTION_ENDPOINT = "/oauth2/default/introspect";
 
     protected function setUp(): void
     {
@@ -78,7 +78,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -95,7 +95,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -103,7 +103,7 @@ class IntrospectionTest extends TestCase
         $this->assertEquals($this->client->getClientId(), $responseBody->client_id);
 
         $this->client->cleanupRevokeAuth();
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -120,7 +120,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => ApiTestClient::BOGUS_ACCESS_TOKEN
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -136,7 +136,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -152,7 +152,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => ApiTestClient::BOGUS_CLIENTSECRET,
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -167,7 +167,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(400, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -182,7 +182,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -198,7 +198,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -206,7 +206,7 @@ class IntrospectionTest extends TestCase
         $this->assertEquals($this->client->getClientId(), $responseBody->client_id);
 
         $this->client->cleanupRevokeAuth();
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -222,7 +222,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => ApiTestClient::BOGUS_ACCESS_TOKEN
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -237,7 +237,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -252,7 +252,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => ApiTestClient::BOGUS_CLIENTSECRET,
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -266,7 +266,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(400, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -282,7 +282,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -299,7 +299,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -307,7 +307,7 @@ class IntrospectionTest extends TestCase
         $this->assertEquals($this->client->getClientId(), $responseBody->client_id);
 
         $this->client->cleanupRevokeAuth();
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -324,7 +324,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => ApiTestClient::BOGUS_REFRESH_TOKEN
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(400, $authResponse->getStatusCode());
     }
 
@@ -337,7 +337,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -353,7 +353,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => ApiTestClient::BOGUS_CLIENTSECRET,
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -368,7 +368,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(400, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -383,7 +383,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -399,7 +399,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -407,7 +407,7 @@ class IntrospectionTest extends TestCase
         $this->assertEquals($this->client->getClientId(), $responseBody->client_id);
 
         $this->client->cleanupRevokeAuth();
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -423,7 +423,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => ApiTestClient::BOGUS_REFRESH_TOKEN
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(400, $authResponse->getStatusCode());
     }
 
@@ -435,7 +435,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => $this->client->getClientSecret(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -450,7 +450,7 @@ class IntrospectionTest extends TestCase
             "client_secret" => ApiTestClient::BOGUS_CLIENTSECRET,
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -464,7 +464,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getRefreshToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(400, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -479,7 +479,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -495,7 +495,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -503,7 +503,7 @@ class IntrospectionTest extends TestCase
         $this->assertEquals($this->client->getClientId(), $responseBody->client_id);
 
         $this->client->cleanupRevokeAuth();
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -519,7 +519,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => ApiTestClient::BOGUS_ACCESS_TOKEN
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -534,7 +534,7 @@ class IntrospectionTest extends TestCase
             "client_id" => ApiTestClient::BOGUS_CLIENTID,
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);
@@ -548,7 +548,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -563,7 +563,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(true, $responseBody->active);
@@ -571,7 +571,7 @@ class IntrospectionTest extends TestCase
         $this->assertEquals($this->client->getClientId(), $responseBody->client_id);
 
         $this->client->cleanupRevokeAuth();
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -586,7 +586,7 @@ class IntrospectionTest extends TestCase
             "client_id" => $this->client->getClientId(),
             "token" => ApiTestClient::BOGUS_ACCESS_TOKEN
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(200, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals(false, $responseBody->active);
@@ -600,7 +600,7 @@ class IntrospectionTest extends TestCase
             "client_id" => ApiTestClient::BOGUS_CLIENTID,
             "token" => $this->client->getAccessToken()
         ];
-        $authResponse = $this->client->post(ApiTestClient::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
+        $authResponse = $this->client->post(self::OAUTH_INTROSPECTION_ENDPOINT, $introspectBody, false);
         $this->assertEquals(401, $authResponse->getStatusCode());
         $responseBody = json_decode($authResponse->getBody());
         $this->assertEquals('invalid_request', $responseBody->error);

--- a/tests/Tests/Api/PatientApiTest.php
+++ b/tests/Tests/Api/PatientApiTest.php
@@ -8,8 +8,7 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
  * Patient API Endpoint Test Cases.
- * NOTE: currently disabled (by naming convention) until work is completed to support running as part of Travis CI
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ * @coversDefaultClass \OpenEMR\RestControllers\PatientRestController
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -151,7 +150,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals($patientUuid, $responseBody["data"]["uuid"]);
         $this->assertEquals($patientPid, $responseBody["data"]["pid"]);
     }
-
 
     /**
      * @covers ::getAll

--- a/tests/Tests/Api/PatientApiTest.php
+++ b/tests/Tests/Api/PatientApiTest.php
@@ -2,13 +2,14 @@
 
 namespace OpenEMR\Tests\Api;
 
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Api\ApiTestClient;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use OpenEMR\RestControllers\PatientRestController;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
  * Patient API Endpoint Test Cases.
- * @coversDefaultClass \OpenEMR\RestControllers\PatientRestController
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -16,18 +17,21 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class PatientApiTest extends TestCase
+#[CoversClass(PatientRestController::class)]
+#[CoversMethod(PatientRestController::class, '::post')]
+#[CoversMethod(PatientRestController::class, '::put')]
+#[CoversMethod(PatientRestController::class, '::getOne')]
+#[CoversMethod(PatientRestController::class, '::getAll')]
+class PatientApiTest extends ApiTestCase
 {
     const PATIENT_API_ENDPOINT = "/apis/default/api/patient";
-    private $testClient;
     private $fixtureManager;
+    private array $patientRecord;
 
     protected function setUp(): void
     {
-        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
-        $this->testClient = new ApiTestClient($baseUrl, false);
-        $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
-
+        parent::setUp();
+        $this->setAuthToken();
         $this->fixtureManager = new FixtureManager();
         $this->patientRecord = (array) $this->fixtureManager->getSinglePatientFixture();
     }
@@ -40,13 +44,13 @@ class PatientApiTest extends TestCase
     }
 
     /**
-     * @covers ::post with an invalid patient request
+     * with an invalid patient request
      */
+    #[Test]
     public function testInvalidPost()
     {
         unset($this->patientRecord["fname"]);
-        $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
-
+        $actualResponse = $this->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
         $this->assertEquals(400, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
         $this->assertEquals(1, count($responseBody["validationErrors"]));
@@ -55,11 +59,12 @@ class PatientApiTest extends TestCase
     }
 
     /**
-     * @covers ::post with a valid patient request
+     * with a valid patient request
      */
+    #[Test]
     public function testPost()
     {
-        $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
+        $actualResponse = $this->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
 
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -75,15 +80,16 @@ class PatientApiTest extends TestCase
     }
 
     /**
-     * @covers ::put with an invalid pid and uuid
+     * with an invalid pid and uuid
      */
+    #[Test]
     public function testInvalidPut()
     {
-        $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
+        $actualResponse = $this->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $this->patientRecord["phone_home"] = "222-222-2222";
-        $actualResponse = $this->testClient->put(self::PATIENT_API_ENDPOINT, "not-a-uuid", $this->patientRecord);
+        $actualResponse = $this->put(self::PATIENT_API_ENDPOINT, "not-a-uuid", $this->patientRecord);
 
         $this->assertEquals(400, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -93,18 +99,19 @@ class PatientApiTest extends TestCase
     }
 
     /**
-     * @covers ::put with a valid resource id and payload
+     * with a valid resource id and payload
      */
+    #[Test]
     public function testPut()
     {
-        $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
+        $actualResponse = $this->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
 
         $patientUuid = $responseBody["data"]["uuid"];
 
         $this->patientRecord["phone_home"] = "222-222-2222";
-        $actualResponse = $this->testClient->put(self::PATIENT_API_ENDPOINT, $patientUuid, $this->patientRecord);
+        $actualResponse = $this->put(self::PATIENT_API_ENDPOINT, $patientUuid, $this->patientRecord);
 
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -116,11 +123,12 @@ class PatientApiTest extends TestCase
     }
 
     /**
-     * @covers ::getOne with an invalid pid
+     * with an invalid pid
      */
+    #[Test]
     public function testGetOneInvalidPid()
     {
-        $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, "not-a-uuid");
+        $actualResponse = $this->getOne(self::PATIENT_API_ENDPOINT, "not-a-uuid");
         $this->assertEquals(400, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -130,18 +138,19 @@ class PatientApiTest extends TestCase
     }
 
     /**
-     * @covers ::getOne with a valid pid
+     * with a valid pid
      */
+    #[Test]
     public function testGetOne()
     {
-        $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
+        $actualResponse = $this->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
         $patientUuid = $responseBody["data"]["uuid"];
         $patientPid = $responseBody["data"]["pid"];
 
-        $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, $patientUuid);
+        $actualResponse = $this->getOne(self::PATIENT_API_ENDPOINT, $patientUuid);
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -154,11 +163,12 @@ class PatientApiTest extends TestCase
     /**
      * @covers ::getAll
      */
+    #[Test]
     public function testGetAll()
     {
         $this->fixtureManager->installPatientFixtures();
 
-        $actualResponse = $this->testClient->get(self::PATIENT_API_ENDPOINT, array("postal_code" => "90210"));
+        $actualResponse = $this->get(self::PATIENT_API_ENDPOINT, array("postal_code" => "90210"));
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -8,7 +8,8 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 
 /**
  * Practitioner API Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ * @coversDefaultClass \OpenEMR\RestControllers\PractitionerRestController
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -2,13 +2,14 @@
 
 namespace OpenEMR\Tests\Api;
 
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Api\ApiTestClient;
+use OpenEMR\RestControllers\PractitionerRestController;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 
 /**
  * Practitioner API Endpoint Test Cases.
- * @coversDefaultClass \OpenEMR\RestControllers\PractitionerRestController
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -17,22 +18,26 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class PractitionerApiTest extends TestCase
+#[CoversClass(PractitionerRestController::class)]
+#[CoversMethod(PractitionerRestController::class, '::post')]
+#[CoversMethod(PractitionerRestController::class, '::put')]
+#[CoversMethod(PractitionerRestController::class, '::getOne')]
+#[CoversMethod(PractitionerRestController::class, '::getAll')]
+class PractitionerApiTest extends ApiTestCase
 {
     const PRACTITIONER_API_ENDPOINT = "/apis/default/api/practitioner";
 
     /**
      * @var ApiTestClient
      */
-    private $testClient;
     private $fixtureManager;
+
+    private $practitionerRecord;
 
     protected function setUp(): void
     {
-        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
-        $this->testClient = new ApiTestClient($baseUrl, false);
-            $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
-
+        parent::setUp();
+        $this->setAuthToken();
         $this->fixtureManager = new PractitionerFixtureManager();
         $this->practitionerRecord = (array) $this->fixtureManager->getSinglePractitionerFixture();
     }
@@ -40,17 +45,17 @@ class PractitionerApiTest extends TestCase
     protected function tearDown(): void
     {
         $this->fixtureManager->removePractitionerFixtures();
-        $this->testClient->cleanupRevokeAuth();
-        $this->testClient->cleanupClient();
+        parent::tearDown();
     }
 
     /**
-     * @covers ::post with an invalid practitioner request
+     * with an invalid practitioner request
      */
+    #[Test]
     public function testInvalidPost()
     {
         unset($this->practitionerRecord["fname"]);
-        $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
+        $actualResponse = $this->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
 
         $this->assertEquals(400, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -60,11 +65,12 @@ class PractitionerApiTest extends TestCase
     }
 
     /**
-     * @covers ::post with a valid practitioner request
+     * with a valid practitioner request
      */
+    #[Test]
     public function testPost()
     {
-        $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
+        $actualResponse = $this->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
 
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -80,15 +86,16 @@ class PractitionerApiTest extends TestCase
     }
 
     /**
-     * @covers ::put with an invalid pid and uuid
+     * with an invalid pid and uuid
      */
+    #[Test]
     public function testInvalidPut()
     {
-        $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
+        $actualResponse = $this->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $this->practitionerRecord["email"] = "help@pennfirm.com";
-        $actualResponse = $this->testClient->put(
+        $actualResponse = $this->put(
             self::PRACTITIONER_API_ENDPOINT,
             "not-a-uuid",
             $this->practitionerRecord
@@ -102,18 +109,19 @@ class PractitionerApiTest extends TestCase
     }
 
     /**
-     * @covers ::put with a valid resource id and payload
+     * with a valid resource id and payload
      */
+    #[Test]
     public function testPut()
     {
-        $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
+        $actualResponse = $this->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
 
         $practitionerUuid = $responseBody["data"]["uuid"];
 
         $this->practitionerRecord["email"] = "help@pennfirm.com";
-        $actualResponse = $this->testClient->put(self::PRACTITIONER_API_ENDPOINT, $practitionerUuid, $this->practitionerRecord);
+        $actualResponse = $this->put(self::PRACTITIONER_API_ENDPOINT, $practitionerUuid, $this->practitionerRecord);
 
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -126,11 +134,12 @@ class PractitionerApiTest extends TestCase
     }
 
     /**
-     * @covers ::getOne with an invalid pid
+     * with an invalid pid
      */
+    #[Test]
     public function testGetOneInvalidId()
     {
-        $actualResponse = $this->testClient->getOne(self::PRACTITIONER_API_ENDPOINT, "not-a-uuid");
+        $actualResponse = $this->getOne(self::PRACTITIONER_API_ENDPOINT, "not-a-uuid");
         $this->assertEquals(400, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -140,18 +149,19 @@ class PractitionerApiTest extends TestCase
     }
 
     /**
-     * @covers ::getOne with a valid pid
+     * with a valid pid
      */
+    #[Test]
     public function testGetOne()
     {
-        $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
+        $actualResponse = $this->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
         $practitionerUuid = $responseBody["data"]["uuid"];
         $practitionerId = $responseBody["data"]["id"];
 
-        $actualResponse = $this->testClient->getOne(self::PRACTITIONER_API_ENDPOINT, $practitionerUuid);
+        $actualResponse = $this->getOne(self::PRACTITIONER_API_ENDPOINT, $practitionerUuid);
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -163,13 +173,14 @@ class PractitionerApiTest extends TestCase
 
 
     /**
-     * @covers ::getAll
+     *
      */
+    #[Test]
     public function testGetAll()
     {
         $this->fixtureManager->installPractitionerFixtures();
 
-        $actualResponse = $this->testClient->get(self::PRACTITIONER_API_ENDPOINT, array("npi" => "0123456789"));
+        $actualResponse = $this->get(self::PRACTITIONER_API_ENDPOINT, array("npi" => "0123456789"));
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);

--- a/tests/Tests/Api/SmartConfigurationTest.php
+++ b/tests/Tests/Api/SmartConfigurationTest.php
@@ -2,67 +2,52 @@
 
 namespace OpenEMR\Tests\Api;
 
-use OpenEMR\RestControllers\AuthorizationController;
-use OpenEMR\RestControllers\FHIR\FhirMetaDataRestController;
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Api\ApiTestClient;
+use OpenEMR\RestControllers\SMART\SMARTConfigurationController;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
 
 /**
  * Capability FHIR Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Stephen Nielson <stephen@nielson.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class SmartConfigurationTest extends TestCase
+#[CoversClass(SMARTConfigurationController::class)]
+#[CoversMethod(SMARTConfigurationController::class, '::getConfig')]
+class SmartConfigurationTest extends ApiTestCase
 {
     const SMART_CONFIG_ENDPOINT = "/apis/default/fhir/.well-known/smart-configuration";
 
-    /**
-     * @var ApiTestClient
-     */
-    private $testClient;
-
-    /**
-     * @var string
-     */
-    private $baseUrl;
-
-    /**
-     * Base url endpoint for oauth2 capability uris
-     * @var string
-     */
-    private $oauthBaseUrl;
-
     protected function setUp(): void
     {
-        $baseUrl = getenv("OPENEMR_BASE_URL_API", true) ?: "https://localhost";
-        $this->testClient = new ApiTestClient($baseUrl, false);
+        parent::setUp();
     }
 
     public function tearDown(): void
     {
-        $this->testClient->cleanupRevokeAuth();
-        $this->testClient->cleanupClient();
+        parent::tearDown();
     }
 
     /**
      * @covers ::get with an invalid path
      */
+    #[Test]
     public function testInvalidPathGet()
     {
-        $actualResponse = $this->testClient->get(self::SMART_CONFIG_ENDPOINT . "ss");
+        $actualResponse = $this->get(self::SMART_CONFIG_ENDPOINT . "ss");
         $this->assertEquals(401, $actualResponse->getStatusCode());
     }
 
     /**
-     * @covers ::get
+     *
      */
+    #[Test]
     public function testGet()
     {
-        $actualResponse = $this->testClient->get(self::SMART_CONFIG_ENDPOINT);
+        $actualResponse = $this->get(self::SMART_CONFIG_ENDPOINT);
         $this->assertEquals(200, $actualResponse->getStatusCode());
     }
 }

--- a/tests/Tests/Common/Uuid/UuidRegistryTest.php
+++ b/tests/Tests/Common/Uuid/UuidRegistryTest.php
@@ -27,8 +27,8 @@ class UuidRegistryTest extends TestCase
 
     /**
      * Tests bi-directional uuid conversions
-     * @covers ::uuidToBytes
-     * @covers ::uuidToString
+     * @covers \OpenEMR\Common\Uuid\UuidRegistry::uuidToBytes
+     * @covers \OpenEMR\Common\Uuid\UuidRegistry::uuidToString
      */
     public function testUuidConversions()
     {

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -184,6 +184,10 @@ abstract class BaseFixtureManager
 
     private function isFunctionCall($value)
     {
+        // preg_match doesn't allow a null value
+        if (is_null($value)) {
+            return false;
+        }
         return preg_match("/[a-zA-Z]+\(['a-zA-Z_0-9\-]*\)/", $value) === 1;
     }
 

--- a/tests/Tests/Fixtures/FixtureManagerTest.php
+++ b/tests/Tests/Fixtures/FixtureManagerTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
- * @coversDefaultClass OpenEMR\Tests\Fixture\FixtureManager
+ * @coversDefaultClass \OpenEMR\Tests\Fixtures\FixtureManager
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -117,7 +117,7 @@ class FixtureManagerTest extends TestCase
     }
 
     /**
-     * @covers ::getPatientFixture
+     * @covers ::getSinglePatientFixture
      */
     public function testGetPatientFixture()
     {

--- a/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
@@ -1,15 +1,5 @@
 <?php
 
-/**
- * FHIR Allergy Intolerance Service Query Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPatientService
- * @package   OpenEMR
- * @link      http://www.open-emr.org
- * @author    Stephen Nielson <stephen@nielson.org>
- * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
- * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- */
-
 namespace OpenEMR\Tests\Services\FHIR;
 
 use OpenEMR\Common\Database\QueryUtils;
@@ -20,6 +10,16 @@ use OpenEMR\Services\FHIR\FhirUrlResolver;
 use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
+/**
+ * FHIR Allergy Intolerance Service Query Tests
+ *
+ * @coversDefaultClass \OpenEMR\Services\FHIR\FhirAllergyIntoleranceService
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
 class FhirAllergyIntoleranceServiceQueryTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
@@ -10,7 +10,7 @@ use OpenEMR\Services\FHIR\FhirOrganizationService;
 
 /**
  * FHIR Organization Service Crud Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirOrganizationService
+ * @coversDefaultClass \OpenEMR\Services\FHIR\FhirOrganizationService
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -47,7 +47,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests a successful insert operation
      * @covers ::insert
-     * @covers ::insertOpenEMRRecord
      */
     public function testInsert()
     {
@@ -64,7 +63,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests an insert operation where an error occurs
      * @covers ::insert
-     * @covers ::insertOpenEMRRecord
      */
     public function testInsertWithErrors()
     {
@@ -77,7 +75,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests a successful update operation
      * @covers ::update
-     * @covers ::updateOpenEMRRecord
      */
     public function testUpdate()
     {
@@ -104,7 +101,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests an update operation where an error occurs
      * @covers ::update
-     * @covers ::updateOpenEMRRecord
      */
     public function testUpdateWithErrors()
     {


### PR DESCRIPTION
Implemented code coverage collection for the api test suite.  Need to
figure out how to use the phpunit cache warmup for grabbing all of the
src directory.  When the src directory is included the tests slow down
to a crawl and we get api timeouts.  For now in this experiment just did
an initial run for building the coverage files which get stored in the
coverage directory. I hard-code the files in the
CoverageHelper::createTargetedCodeCoverage() method and will need to
figure out the directory traversal later.

Afterwards to compile all the coverage into an aggegrated report the
following commands can be run:
```
 php -d memory_limit=512M vendor/bin/phpcov merge coverage --html=coverage/html --clover=coverage/clover.xml && rm cov
erage/*.cov
```

I add two environment variables for the docker-compose docker
environment.  One to turn on the coverage report collection which will
be turned off by default (and respected in the CoverageHelper class) and
another to tell xdebug to collect coverage metrics.

This is a screenshot of the overview in coverage/html/index.html
![image](https://github.com/user-attachments/assets/8e955053-b5b1-4e79-8328-2c7b3e695e33)

RestControllerHelper.php
![image](https://github.com/user-attachments/assets/3eef261f-c98e-44e9-8aaf-4e698ff435a7)

RestControllerHelper::handleProcessingResult
![image](https://github.com/user-attachments/assets/cd55895d-9d6f-4f24-a39a-a13d7639f980)

